### PR TITLE
✅ Added GitHub action building docker images on push

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,93 @@
+# File written by GitHub user MayNiklas, never versions can be found in https://github.com/MayNiklas/github-actions
+#
+# GitHub action for building new docker images when there is a new commit on the main branch
+# Images are getting pushed to Dockerhub
+#
+# File location: .github/workflows/image.yml
+#
+# Used GitHub secrets:
+# DOCKER_USERNAME
+# DOCKER_PASSWORD
+# DOCKER_REPOSITORY
+
+
+name: Building docker containers
+on:
+  push:
+    branches: main
+jobs:
+  building-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: build the image for amd64
+        run: |
+          docker buildx build --push \
+            --tag "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":amd64-latest \
+            --platform linux/amd64 .
+
+  building-arm64v8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: build the image for arm64v8
+        run: |
+          docker buildx build --push \
+            --tag "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm64v8-latest \
+            --platform linux/arm64 .
+
+  building-arm32v7:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: build the image for arm32v7
+        run: |
+          docker buildx build --push \
+            --tag "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm32v7-latest \
+            --platform linux/arm/v7 .
+
+  manifest-create:
+    needs: [building-arm64v8, building-arm32v7, building-amd64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          
+      - name: create manifest
+        run: |
+          docker manifest create \
+          "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":latest \
+          --amend "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm64v8-latest \
+          --amend "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm32v7-latest \
+          --amend "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":amd64-latest
+           
+      - name: push manifest
+        run: |
+          docker manifest push "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":latest


### PR DESCRIPTION
As requested, I implemented the wished changes for the project:
- container automatically gets build on every push to the main branch
- container gets pushed to dockerhub, GitHub secrets are used for that
- builds for arm64v8, arm32v7 & amd64
- creates the :latest manifest