### PR TITLE
↗️ Imporved bot commands and outputs

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -121,11 +121,12 @@ class Analyzer:
         #plt.gcf().autofmt_xdate()
         
         plt.figtext(0.5, 0.02, \
-"Tage ohne Aktualisierung der Daten werden ausgelassen.\n \
-Dies ist eine Visualisierung der vom Kreis Ahrweiler täglich \
+'Dies ist eine Visualisierung der vom Kreis Ahrweiler täglich \
 auf der Homepage veröffentlichten Fallzahlen. \n \
+Tage ohne Aktualisierung der Daten werden ausgelassen. \
+Eine Lücke in den Daten führt zu einem "doppelten" Anstieg am Folgetag.\n\
 Für die Richtigkeit der Zahlen wird keinerlei Haftung übernommen. \
-Dieser Bot ist ein privates Projekt und steht in keiner Verbindung zu einer Behörde.",
+Dieser Bot ist ein privates Projekt und steht in keiner Verbindung zu einer Behörde.',
             color=("#a8a8a8"), fontsize="xx-small", ha="center") #backgroundcolor=("#dbdbdb")
 
         plt.figtext(0.95, 0.43, "t.me/aw_covidbot", rotation="vertical",\

--- a/src/bot.py
+++ b/src/bot.py
@@ -142,7 +142,7 @@ dispatcher.add_handler(grafschaft_handler)
 
 #neuenahr/ahrweiler
 neuenahr_handler = CommandHandler(['abo_neuenahr', 'sub_neuenahr',\
-                     'aboneuenahr', 'subneuenahr', 'aneuenahr','abo_bad_neuenahr', 'sneuenahr'\
+                     'aboneuenahr', 'subneuenahr', 'aneuenahr','abo_bad_neuenahr', 'sneuenahr',\
                      'abo_ahrweiler', 'sub_ahrweiler',\
                      'aboahrweiler', 'subahrweiler', 'aahrweiler', 'sahrweiler'],\
                      tgs.tgl_neuenahr)

--- a/src/bot.py
+++ b/src/bot.py
@@ -95,59 +95,84 @@ dispatcher.add_handler(echo_handler)
 caps_handler = CommandHandler('caps', btc.caps)
 dispatcher.add_handler(caps_handler)
 
-help_handler = CommandHandler('hilfe', btc.help)
-dispatcher.add_handler(help_handler)
 
-help_handler = CommandHandler('help', btc.help)
-dispatcher.add_handler(help_handler)
-
-show_handler = CommandHandler('show', btc.show)
+show_handler = CommandHandler(['zeig', 'show', 'zg', 'sh', 's', 'z'], btc.show)
 dispatcher.add_handler(show_handler)
 
-#aliases for /show /help
-sh_handler = CommandHandler('sh', btc.show)
-dispatcher.add_handler(sh_handler)
-
-hilfe_handler = CommandHandler('hilfe', btc.help)
+hilfe_handler = CommandHandler(['hilfe', 'hilf', 'help', 'h', 'abo', 'a'], btc.help)
 dispatcher.add_handler(hilfe_handler)
 
-h_handler = CommandHandler('h', btc.help)
-dispatcher.add_handler(h_handler)
 
 ####
-kreis_handler = CommandHandler('kreis', tgs.kreis)
+#kreis
+kreis_handler = CommandHandler(['abo_kreis', 'sub_kreis',\
+                    'abokreis', 'subkreis', 'akreis', 'skreis'],\
+                    tgs.tgl_kreis)
 dispatcher.add_handler(kreis_handler)
 
-adenau_handler = CommandHandler('adenau', tgs.adenau)
+#adenau
+adenau_handler = CommandHandler(['abo_adenau', 'sub_adenau',\
+                    'aboadenau', 'subadenau', 'aadenau', 'sadenau'],\
+                     tgs.tgl_adenau)
 dispatcher.add_handler(adenau_handler)
 
-altenahr_handler = CommandHandler('altenahr', tgs.altenahr)
+#altenahr
+altenahr_handler = CommandHandler(['abo_altenahr', 'sub_altenahr',\
+                    'aboaltenahr', 'subaltenahr', 'aaltenahr', 'saltenahr'],\
+                    tgs.tgl_altenahr)
 dispatcher.add_handler(altenahr_handler)
 
-breisig_handler = CommandHandler('breisig', tgs.breisig)
+#breisig
+breisig_handler = CommandHandler(['abo_breisig', 'sub_breisig', 'abobreisig', 'subbreisig',\
+                    'abreisig', 'abo_bad_breisig', 'sub_bad_breisig', 'sbreisig'],\
+                    tgs.tgl_breisig)
 dispatcher.add_handler(breisig_handler)
 
-brohltal_handler = CommandHandler('brohltal', tgs.brohltal)
+#brohltal
+brohltal_handler = CommandHandler(['abo_brohltal', 'sub_brohltal',\
+                     'abobrohltal', 'subbrohltal', 'abrohltal', 'sbrohltal'],\
+                     tgs.tgl_brohltal)
 dispatcher.add_handler(brohltal_handler)
 
-grafschaft_handler = CommandHandler('grafschaft', tgs.grafschaft)
+#grafschaft
+grafschaft_handler = CommandHandler(['abo_grafschaft', 'sub_grafschaft',\
+                     'abografschaft', 'subgrafschaft', 'agrafschaft', 'sgrafschaft'],\
+                    tgs.tgl_grafschaft)
 dispatcher.add_handler(grafschaft_handler)
 
-neuenahr_handler = CommandHandler('neuenahr', tgs.neuenahr)
+#neuenahr/ahrweiler
+neuenahr_handler = CommandHandler(['abo_neuenahr', 'sub_neuenahr',\
+                     'aboneuenahr', 'subneuenahr', 'aneuenahr','abo_bad_neuenahr', 'sneuenahr'\
+                     'abo_ahrweiler', 'sub_ahrweiler',\
+                     'aboahrweiler', 'subahrweiler', 'aahrweiler', 'sahrweiler'],\
+                     tgs.tgl_neuenahr)
 dispatcher.add_handler(neuenahr_handler)
 
-remagen_handler = CommandHandler('remagen', tgs.remagen)
+#remagen
+remagen_handler = CommandHandler(['abo_remagen', 'sub_remagen',\
+                    'aboremagen', 'subremagen', 'aremagen', 'sremagen'],\
+                     tgs.tgl_remagen)
 dispatcher.add_handler(remagen_handler)
 
-sinzig_handler = CommandHandler('sinzig', tgs.sinzig)
+#sinzig
+sinzig_handler = CommandHandler(['abo_sinzig', 'sub_sinzig',\
+                    'abosinzig', 'subsinzig', 'asinzig', 'ssinzig'],\
+                     tgs.tgl_sinzig)
 dispatcher.add_handler(sinzig_handler)
 
-kreis_handler = CommandHandler('kreis', tgs.kreis)
+#kreis
+kreis_handler = CommandHandler(['abo_kreis', 'sub_kreis',\
+                     'abokreis', 'subkreis', 'akreis', 'skreis'],\
+                     tgs.tgl_kreis)
 dispatcher.add_handler(kreis_handler)
 
-alle_handler = CommandHandler('alle', tgs.alle)
+#alle
+alle_handler = CommandHandler(['abo_alle', 'sub_alle',\
+                     'aboalle', 'suballe', 'aalle', 'salle'],\
+                     tgs.tgl_alle)
 dispatcher.add_handler(alle_handler)
 
+#['abo_', 'sub_', 'abo', 'sub', 'a']
 
 #bot.send_message(chat_id=402239048, text="Automated text")
 

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -6,6 +6,13 @@ def setup(wrtr):
     global writer
     writer = wrtr
 
+abo_text = "\
+/abo_adenau \n/abo_ahrweiler \n/abo_altenahr \n/abo_breisig \n/abo_brohltal \n/abo_grafschaft\
+\n/abo_neuenahr \n/abo_remagen \n/abo_sinzig \n\
+/abo_alle\n"
+    #/kreis\n-> Die aktuellsten Zahlen für den ganzen Kreis.\n\
+    #Standardmäßig sind Sie nur für Updates zum gesamzen Kreis angemeldet.
+
 def start(update, context):
     """Command triggered at /start"""
     print(context.args)
@@ -25,39 +32,33 @@ Mit freundlichen Grüßen und bleiben Sie gesund!\n\
 Covid Update Bot", chat_id=update.effective_chat.id)
 
     context.bot.send_message(chat_id=update.effective_chat.id,
-text="Wählen Sie die Regionen, über die Sie täglich informiert werden möchten:\n\
-/adenau \n/altenahr \n/breisig \n/brohltal \n/grafschaft \n/neuenahr \n\
-/remagen \n/sinzig \n\
-/alle\n\
-Sie können die Befehle entweder durch drauf tippen, oder durch Eingabe in den Chat ausführen.\n\
-'Alle' abonniert alle einzeln aufgeführten Regionen mit nur einem Klick.\n\
-Der Einfacheit halber wurde die Region Bad Neuenahr-Ahrweiler als 'Neuenahr' und \
-Bad Breisig als 'Breisig' aufgeführt.\n\
-Nutzen Sie /hilfe für weitere Optionen.")
+text=f'Wählen Sie die Regionen, über die Sie täglich informiert werden möchten:\n\
+{abo_text}\
+Bad Neuenahr und Ahrweiler versenden die selbe Grafik. \n\
+Nutzen Sie /hilfe für weitere Optionen.\n\
+Alle Befehle sind klickbar.\n')
 
 
 def help(update, context):
     """The help command"""
-    context.bot.send_message(text=f"Hallo, \
-das hier sind alle verfügbaren Befehle:\n\
-Mit den folgenden Befehlen können Sie automatische Updates zu bestimmten \
-Regionen erhalten, sobald neue Zahlen verfügbar sind:\n\
-/adenau \n/altenahr \n/breisig \n/brohltal \n/grafschaft \n/neuenahr \n\
-/remagen \n/sinzig \n\
-/alle\n-> Abonniert alle einzeln aufgeführten Updates mit nur einem Klick.\n\n\
-Sie können auf die hervorgehobenen Befehle draufklicken, oder diese manuell in \
-diesen Chat schicken, um den Befehl einzugeben.\n\
+    context.bot.send_message(text=f'Hallo, \
+das hier sind alle verfügbaren Befehle:\n\n\
+Befehle um automatische Updates zu gewählten \
+Regionen zu erhalten, sobald neue Zahlen verfügbar sind:\n\
+{abo_text}\
+Abo_alle abonniert alle Updates mit nur einem Klick.\n\n\
+Bad Neuenahr und Ahrweiler versenden die selbe Grafik. \n\
 Durch erneutes Eingeben eines Befehls deabonnieren Sie die angegebene Kategorie.\n\n\
 \
-/show Schlüsselwort oder /sh Schlüsselwort\n \
--> Ruft den aktuellsten Graphen für diese Region ab.\n \
-Die Schlüsselwörter sind die oben hervorgehobenen Worte.\n\
-Beispiel: '/sh breisig' ruft den Graphen für Bad Breisig ab.\n \
-\n\n\
+Graphen für eine Region abrufen:\n\
+/zeig Region - kurz: /z\n\
+Die Regionen sind die Namen aus den oben gelisteten Abo-Befehlen.\n\
+Beispiel: /z breisig\n\n\
+Sie können die hervorgehobenen Befehle anklicken, oder diese in \
+den Chat eingeben, um den Befehl auszuführen.\n\n\
 Bleiben Sie gesund!\n\
-Corona Bot Kreis Ahrweiler", chat_id=update.effective_chat.id)
-    #/kreis\n-> Die aktuellsten Zahlen für den ganzen Kreis.\n\
-    #Standardmäßig sind Sie nur für Updates zum gesamzen Kreis angemeldet.
+Corona Bot Kreis Ahrweiler', chat_id=update.effective_chat.id)
+
 
 
 def show(update, context):

--- a/src/toggle_subs.py
+++ b/src/toggle_subs.py
@@ -5,7 +5,7 @@ def setup(wrtr):
     global writer
     writer = wrtr
 
-def kreis(update, context):
+def tgl_kreis(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["kreis"]:
@@ -18,7 +18,7 @@ def kreis(update, context):
                 chat_id=update.effective_chat.id)
     writer.write()
 
-def adenau(update, context):
+def tgl_adenau(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["adenau"]:
@@ -32,7 +32,7 @@ def adenau(update, context):
         writer.write()
     writer.write()
 
-def altenahr(update, context):
+def tgl_altenahr(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["altenahr"]:
@@ -45,7 +45,7 @@ def altenahr(update, context):
                 chat_id=update.effective_chat.id)
     writer.write()
 
-def breisig(update, context):
+def tgl_breisig(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["bad breisig"]:
@@ -58,7 +58,7 @@ def breisig(update, context):
                 chat_id=update.effective_chat.id)
     writer.write()
 
-def brohltal(update, context):
+def tgl_brohltal(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["brohltal"]:
@@ -71,7 +71,7 @@ def brohltal(update, context):
                 chat_id=update.effective_chat.id)
     writer.write()
 
-def grafschaft(update, context):
+def tgl_grafschaft(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["grafschaft"]:
@@ -84,7 +84,7 @@ def grafschaft(update, context):
                 chat_id=update.effective_chat.id)
     writer.write()
 
-def neuenahr(update, context):
+def tgl_neuenahr(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["bad neuenahr-ahrweiler"]:
@@ -97,7 +97,7 @@ def neuenahr(update, context):
                 chat_id=update.effective_chat.id)
     writer.write()
 
-def remagen(update, context):
+def tgl_remagen(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["remagen"]:
@@ -110,8 +110,9 @@ def remagen(update, context):
                 chat_id=update.effective_chat.id)
     writer.write()
 
-def sinzig(update, context):
+def tgl_sinzig(update, context):
     #csv_utils.write(str(update.message.chat.id), "sinzig")
+    print("sz")
     chat = writer.add(update.message.chat)
     s = chat.settings
     print("sinzig: ", s["sinzig"])
@@ -130,7 +131,7 @@ def sinzig(update, context):
     writer.write()
     print()
 
-def alle(update, context):
+def tgl_alle(update, context):
     chat = writer.add(update.message.chat)
     s = chat.settings
     if s["all"]:


### PR DESCRIPTION
This PR introduces aliases for all commands such as `/show` -> `/sh`, `/s`.
I was able to remove some command handlers while doing this.
There is also a rather huge polish of the `/help` and `/start` message.
And I renamed all the toggle-commands from `location` to `tgl_location` so the location-only functiosn are free for the planned improvements of the show function. 