### PR TITLE
🆕 New menu structure and improved show command

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -29,7 +29,6 @@ dispatcher = updater.dispatcher
 bot = Bot(token=API_Key)
 
 
-
 logging.basicConfig(
         filename="data/events.log",
         level= logging.INFO,
@@ -116,9 +115,13 @@ show_handler = CommandHandler(['Adenau', 'Ahrweiler', 'Breisig', 'Brohltal',\
                     ], btc.show)
 dispatcher.add_handler(show_handler)
 
+
 hilfe_handler = CommandHandler(['hilfe', 'hilf', 'help', 'h', 'abo', 'a'], btc.help)
 dispatcher.add_handler(hilfe_handler)
 
+
+about_handler = CommandHandler('about', btc.about)
+dispatcher.add_handler(about_handler)
 
 ####
 #kreis

--- a/src/bot.py
+++ b/src/bot.py
@@ -96,7 +96,10 @@ caps_handler = CommandHandler('caps', btc.caps)
 dispatcher.add_handler(caps_handler)
 
 
-show_handler = CommandHandler(['zeig', 'show', 'zg', 'sh', 's', 'z'], btc.show)
+show_handler = CommandHandler(['Adenau', 'Ahrweiler', 'Breisig', 'Brohltal',\
+                    'Grafschaft', 'Neuenahr', 'Remagen', 'Sinzig', \
+                    'Bad_Breisig', 'Bad_Neuenahr', 'Bad_Neuenahr_Ahrweiler'\
+                    ], btc.show)
 dispatcher.add_handler(show_handler)
 
 hilfe_handler = CommandHandler(['hilfe', 'hilf', 'help', 'h', 'abo', 'a'], btc.help)

--- a/src/bot.py
+++ b/src/bot.py
@@ -96,6 +96,16 @@ caps_handler = CommandHandler('caps', btc.caps)
 dispatcher.add_handler(caps_handler)
 
 
+menu_show_handler = CommandHandler(['zeig_graph', 'zeig', 'show', 'zg', 'sh', 's', 'z'],\
+                    btc.menu_show)
+dispatcher.add_handler(menu_show_handler)
+
+
+menu_abo_handler = CommandHandler(['abo', 'sub', 'abonnieren'],\
+                    btc.menu_abo)
+dispatcher.add_handler(menu_abo_handler)
+
+
 menu_menu_handler = CommandHandler(['menu', 'menue'],\
                     btc.menu_menu)
 dispatcher.add_handler(menu_menu_handler)

--- a/src/bot.py
+++ b/src/bot.py
@@ -96,6 +96,10 @@ caps_handler = CommandHandler('caps', btc.caps)
 dispatcher.add_handler(caps_handler)
 
 
+menu_menu_handler = CommandHandler(['menu', 'menue'],\
+                    btc.menu_menu)
+dispatcher.add_handler(menu_menu_handler)
+
 show_handler = CommandHandler(['Adenau', 'Ahrweiler', 'Breisig', 'Brohltal',\
                     'Grafschaft', 'Neuenahr', 'Remagen', 'Sinzig', \
                     'Bad_Breisig', 'Bad_Neuenahr', 'Bad_Neuenahr_Ahrweiler'\

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -10,8 +10,8 @@ def setup(wrtr):
     writer = wrtr
 
 abo_text = "\
-/abo_adenau \n/abo_ahrweiler \n/abo_altenahr \n/abo_breisig \n/abo_brohltal \n/abo_grafschaft\
-\n/abo_neuenahr \n/abo_remagen \n/abo_sinzig \n\
+/abo_adenau \n/abo_altenahr \n/abo_breisig \n/abo_brohltal \n/abo_grafschaft\
+\n/abo_bad_neuenahr_ahrweiler \n/abo_remagen \n/abo_sinzig \n\
 /abo_alle\n"
     #/kreis\n-> Die aktuellsten Zahlen für den ganzen Kreis.\n\
     #Standardmäßig sind Sie nur für Updates zum gesamzen Kreis angemeldet.
@@ -55,33 +55,34 @@ dieser Bot kann Ihnen täglich ein Update senden, so bald es neue Zahlen gibt.\n
 Bitte nehmen Sie zur Kenntniss, dass es sich bei dem Bot um ein privates Projekt handelt.\n\
 \n\
 Mit freundlichen Grüßen und bleiben Sie gesund!\n\
-Covid Update Bot", chat_id=update.effective_chat.id)
+Covid Update Bot", reply_markup=menu_kb, chat_id=update.effective_chat.id)
 
     context.bot.send_message(chat_id=update.effective_chat.id,
-text=f'Wählen Sie die Regionen, über die Sie täglich informiert werden möchten:\n\
-{abo_text}\
-Bad Neuenahr und Ahrweiler versenden die selbe Grafik. \n\
-Nutzen Sie /hilfe für weitere Optionen.\n\
-Alle Befehle sind klickbar.\n')
+text=f'Bitte wählen Sie aus den angegebenen Optionen aus, was Sie tun möchten.\n\
+Wählen Sie die Regionen aus, zu denen Sie automatische Updates erhalten wollen:\n\
+/abonnieren\n\
+Lassen Sie sich einzelne Graphen anzeigen:\n\
+/zeig_graph\n\
+Zeigt Ihnen eine List von Befehlen an:\n\
+/hilfe\n\
+')
 
 
 def help(update, context):
     """The help command"""
     context.bot.send_message(text=f'Hallo, \
 das hier sind alle verfügbaren Befehle:\n\n\
-Befehle um automatische Updates zu gewählten \
-Regionen zu erhalten, sobald neue Zahlen verfügbar sind:\n\
-{abo_text}\
-Abo_alle abonniert alle Updates mit nur einem Klick.\n\n\
-Bad Neuenahr und Ahrweiler versenden die selbe Grafik. \n\
-Durch erneutes Eingeben eines Befehls deabonnieren Sie die angegebene Kategorie.\n\n\
+/abo - Öffnet ein Menü zur Auswahl gewünschter Abonnements.\n\
+Erneutes Eingeben eines Befehls deabonniert die angegebene Kategorie.\n\n\
 \
-Graphen für eine Region abrufen:\n\
-/zeig Region - kurz: /z\n\
-Die Regionen sind die Namen aus den oben gelisteten Abo-Befehlen.\n\
-Beispiel: /z breisig\n\n\
-Sie können die hervorgehobenen Befehle anklicken, oder diese in \
-den Chat eingeben, um den Befehl auszuführen.\n\n\
+/zeig - Öffnet einen Dialog, in dem Sie den Graphen zu einer Region abrufen können.\n\
+\n\
+Jeden Befehl, den Sie in einem Dialog finden, können Sie auch von Hand eingeben.\n\n\
+Ihnen wird das Menü nicht angezeigt?\n\
+Nutzen Sie /menu\n\
+Sie können zwischen Bot-Tatstur und normaler Tatstur mit einer Schaltfläche \
+in der Text-Zeile hin und her wechseln.\n\
+Hervorgehoben Befehle sind zudem klickbar.\n\n\
 Bleiben Sie gesund!\n\
 Corona Bot Kreis Ahrweiler', reply_markup=menu_kb, chat_id=update.effective_chat.id)
 
@@ -117,6 +118,9 @@ def show(update, context):
             path = f"visuals/{city}-{date}.png"
             print(path)
             with open(path, "rb") as img:
+                context.bot.send_message(text='\
+            /abo   /zeig   /hilfe',\
+                                        chat_id=update.effective_chat.id)
                 context.bot.send_photo(photo=img, chat_id=update.effective_chat.id)
             break #if this point is reached, a valid file is found
         except:

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -1,6 +1,9 @@
 import csv_utils
 import datetime
 
+from telegram import KeyboardButton
+from telegram import ReplyKeyboardMarkup
+
 def setup(wrtr):
     """passing csv access object to this"""
     global writer
@@ -18,6 +21,20 @@ abo_text = "\
 menu2_kb = ReplyKeyboardMarkup([
                     ['/abonnieren'], ['/zeig_graph'], ['/hilfe'] \
                     ], one_time_keyboard=False)
+
+show_kb = ReplyKeyboardMarkup([
+                    ['/Adenau', '/Bad_Breisig', '/Brohltal'], \
+                    [ '/Grafschaft', '/Remagen', '/Sinzig'],\
+                    ['/Bad_Neuenahr_Ahrweiler'] \
+                    ], one_time_keyboard=True)
+
+abo_kb = ReplyKeyboardMarkup([
+    ['/abo_adenau', '/abo_altenahr', '/abo_brohltal'],
+    ['/abo_grafschaft', '/abo_remagen', '/abo_sinzig'],
+    ['/abo_alle', '/abo_bad_breisig'],
+    ['/abo_bad_neuenahr_ahrweiler',]
+    ], one_time_keyboard=True)
+
 def start(update, context):
     """Command triggered at /start"""
     print(context.args)
@@ -69,6 +86,15 @@ def menu_menu(update, context):
     context.bot.send_message(text='Was wollen Sie als nächstes tun?\n\
             /abo   /zeig   /hilfe',
                 reply_markup=menu2_kb, chat_id=update.effective_chat.id)
+
+def menu_show(update, context):
+    context.bot.send_message(text='Bitte wählen Sie eine Region.',
+                reply_markup=show_kb, chat_id=update.effective_chat.id)
+
+
+def menu_abo(update, context):
+    context.bot.send_message(text='Bitte wählen Sie eine Region.',
+                reply_markup=abo_kb, chat_id=update.effective_chat.id)
 
 
 def show(update, context):

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -13,6 +13,11 @@ abo_text = "\
     #/kreis\n-> Die aktuellsten Zahlen für den ganzen Kreis.\n\
     #Standardmäßig sind Sie nur für Updates zum gesamzen Kreis angemeldet.
 
+#this secondary keyboard is needed to make the keyboard
+#pop up dagain when user disabled the custom keyboard and /help won't appear
+menu2_kb = ReplyKeyboardMarkup([
+                    ['/abonnieren'], ['/zeig_graph'], ['/hilfe'] \
+                    ], one_time_keyboard=False)
 def start(update, context):
     """Command triggered at /start"""
     print(context.args)
@@ -59,6 +64,11 @@ den Chat eingeben, um den Befehl auszuführen.\n\n\
 Bleiben Sie gesund!\n\
 Corona Bot Kreis Ahrweiler', chat_id=update.effective_chat.id)
 
+
+def menu_menu(update, context):
+    context.bot.send_message(text='Was wollen Sie als nächstes tun?\n\
+            /abo   /zeig   /hilfe',
+                reply_markup=menu2_kb, chat_id=update.effective_chat.id)
 
 
 def show(update, context):

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -16,6 +16,10 @@ abo_text = "\
     #/kreis\n-> Die aktuellsten Zahlen für den ganzen Kreis.\n\
     #Standardmäßig sind Sie nur für Updates zum gesamzen Kreis angemeldet.
 
+menu_kb = ReplyKeyboardMarkup([
+                    ['/abonnieren'], ['/zeig_graph'], ['/hilfe', '/about'] \
+                    ], one_time_keyboard=False)
+
 #this secondary keyboard is needed to make the keyboard
 #pop up dagain when user disabled the custom keyboard and /help won't appear
 menu2_kb = ReplyKeyboardMarkup([
@@ -79,7 +83,7 @@ Beispiel: /z breisig\n\n\
 Sie können die hervorgehobenen Befehle anklicken, oder diese in \
 den Chat eingeben, um den Befehl auszuführen.\n\n\
 Bleiben Sie gesund!\n\
-Corona Bot Kreis Ahrweiler', chat_id=update.effective_chat.id)
+Corona Bot Kreis Ahrweiler', reply_markup=menu_kb, chat_id=update.effective_chat.id)
 
 
 def menu_menu(update, context):
@@ -124,6 +128,15 @@ Sind sie sicher, dass Sie eine gültige Region eigegeben haben? - \
 Die Schlüsselwörter sind die selben, die Sie zum abonnieren verwenden. \n\
 Nutzen Sie /help für mehr Informationen", chat_id=update.effective_chat.id)
 
+
+def about(update, context):
+    context.bot.send_message(text='Dieser Bot ist ein Open Source Projekt.\n\
+Das bedeutet, dass Sie den gesamten Quelltext online einsehen können.\n\
+Dieses Projekt steht weder mit dem Kreis Ahrweiler, \
+noch einer anderen Behörde in Verbindung.\n\
+Für Richtigkeit und Vollständigkeit der Daten wird keine Haftung übernommen.\n\
+https://github.com/nonchris/covid-data-bot', \
+        chat_id=update.effective_chat.id, reply_markup=menu_kb)
 
 def caps(update, context):
     """

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -63,18 +63,9 @@ Corona Bot Kreis Ahrweiler', chat_id=update.effective_chat.id)
 
 def show(update, context):
     city = ""
-    try:
-        #trying to get a valid keyword from args
-        #the word must be precise otherwise the filename will be faulty
-        #using the mapping dict from csv_utils
-        city = csv_utils.translator[" ".join(context.args).replace('/', '').lower()]
-
-    #if no valid input was given
-    except KeyError as ke:
-        context.bot.send_message(text="Geben Sie bitte ein gültiges Schlüsselwort ein.\n\
-Die Schlüsselwörter sind die selben, die Sie zum abonnieren verwenden. \n\
-Nutzen Sie /help für mehr Informationen.", chat_id=update.effective_chat.id)
-        return
+    #getting word that actually triggerd that command
+    #using the mapping dict from csv_utils
+    city = csv_utils.translator[update['message']['text'][1:].lower()]
     
     #actual part for getting and sending the graph
     today = datetime.date.today()

--- a/src/csv_utils.py
+++ b/src/csv_utils.py
@@ -19,7 +19,11 @@ translator = {"kreis": "kreis",
             "bad neuenahr-ahrweiler": "Bad Neuenahr-Ahrweiler",
             "bad neuenahr": "Bad Neuenahr-Ahrweiler",
             "ahrweiler": "Bad Neuenahr-Ahrweiler",
-            }
+
+            "bad_breisig": "Bad Breisig",
+            "bad_neuenahr_ahrweiler": "Bad Neuenahr-Ahrweiler",
+            "bad_neuenahr": "Bad Neuenahr-Ahrweiler",
+             }
 
 def str_to_bool(s: str):
     status = {"True": True,

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -1,3 +1,5 @@
+from bot_handlers import menu2_kb
+
 def setup(wrtr):
     """passing csv access object to this file"""
     global writer
@@ -5,5 +7,6 @@ def setup(wrtr):
 
 def echo(update, context):
     """Happens when somebody writes something"""
-    context.bot.send_message(chat_id=update.effective_chat.id, \
-        text="Nutzen Sie /help oder /h und /start, um mehr zu über den Bot zu erfahren.")
+    context.bot.send_message(text='Was möchten Sie machen?\n\
+            /abo   /zeig   /hilfe',
+                reply_markup=menu2_kb, chat_id=update.effective_chat.id)

--- a/src/toggle_subs.py
+++ b/src/toggle_subs.py
@@ -10,11 +10,13 @@ def tgl_kreis(update, context):
     s = chat.settings
     if s["kreis"]:
         s["kreis"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für den Kreis Ahrweiler ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für den Kreis Ahrweiler ausgetragen. \n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["kreis"] = True
-        context.bot.send_message(text="Sie haben Updates für den Kreis Ahrweiler aboniert",
+        context.bot.send_message(text="Sie haben Updates für den Kreis Ahrweiler aboniert. \n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()
 
@@ -23,11 +25,13 @@ def tgl_adenau(update, context):
     s = chat.settings
     if s["adenau"]:
         s["adenau"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für Adenau ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für Adenau ausgetragen. \n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["adenau"] = True
-        context.bot.send_message(text="Sie haben Updates für Adenau aboniert",
+        context.bot.send_message(text="Sie haben Updates für Adenau aboniert. \n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
         writer.write()
     writer.write()
@@ -37,11 +41,13 @@ def tgl_altenahr(update, context):
     s = chat.settings
     if s["altenahr"]:
         s["altenahr"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für Altenahr ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für Altenahr ausgetragen. \n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["altenahr"] = True
-        context.bot.send_message(text="Sie haben Updates für Altenahr aboniert",
+        context.bot.send_message(text="Sie haben Updates für Altenahr aboniert. \n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()
 
@@ -50,11 +56,13 @@ def tgl_breisig(update, context):
     s = chat.settings
     if s["bad breisig"]:
         s["bad breisig"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für Bad Breisig ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für Bad Breisig ausgetragen. \n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["bad breisig"] = True
-        context.bot.send_message(text="Sie haben Updates für Bad Breisig aboniert",
+        context.bot.send_message(text="Sie haben Updates für Bad Breisig aboniert.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()
 
@@ -63,11 +71,13 @@ def tgl_brohltal(update, context):
     s = chat.settings
     if s["brohltal"]:
         s["brohltal"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für das Brohltal ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für das Brohltal ausgetragen.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["brohltal"] = True
-        context.bot.send_message(text="Sie haben Updates für das Brohltal aboniert",
+        context.bot.send_message(text="Sie haben Updates für das Brohltal aboniert.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()
 
@@ -76,11 +86,13 @@ def tgl_grafschaft(update, context):
     s = chat.settings
     if s["grafschaft"]:
         s["grafschaft"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für die Grafschaft ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für die Grafschaft ausgetragen.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["grafschaft"] = True
-        context.bot.send_message(text="Sie haben Updates für die Grafschaft aboniert",
+        context.bot.send_message(text="Sie haben Updates für die Grafschaft aboniert.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()
 
@@ -89,11 +101,13 @@ def tgl_neuenahr(update, context):
     s = chat.settings
     if s["bad neuenahr-ahrweiler"]:
         s["bad neuenahr-ahrweiler"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für Bad Neuenahr-Ahrweiler ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für Bad Neuenahr-Ahrweiler ausgetragen.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["bad neuenahr-ahrweiler"] = True
-        context.bot.send_message(text="Sie haben Updates für Bad Neuenahr-Ahrweiler aboniert",
+        context.bot.send_message(text="Sie haben Updates für Bad Neuenahr-Ahrweiler aboniert.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()
 
@@ -102,11 +116,13 @@ def tgl_remagen(update, context):
     s = chat.settings
     if s["remagen"]:
         s["remagen"] = False
-        context.bot.send_message(text="Sie haben sich aus Updates für Remagen ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für Remagen ausgetragen.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["remagen"] = True
-        context.bot.send_message(text="Sie haben Updates für Remagen aboniert",
+        context.bot.send_message(text="Sie haben Updates für Remagen aboniert.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()
 
@@ -120,12 +136,14 @@ def tgl_sinzig(update, context):
     if s["sinzig"]:
         s["sinzig"] = False
         print("sinzig: ", s["sinzig"])
-        context.bot.send_message(text="Sie haben sich aus Updates für Sinzig ausgetragen",
+        context.bot.send_message(text="Sie haben sich aus Updates für Sinzig ausgetragen.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["sinzig"] = True
         print("sinzig: ", s["sinzig"])
-        context.bot.send_message(text="Sie haben Updates für Sinzig aboniert",
+        context.bot.send_message(text="Sie haben Updates für Sinzig aboniert.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
         #writer.write()
     writer.write()
@@ -137,11 +155,13 @@ def tgl_alle(update, context):
     if s["all"]:
         s["all"] = False
         context.bot.send_message(text="Sie haben sich aus alles umfassenden Updater ausgetragen, \
-es gelten wieder Ihre Einstellungen für einzelne Abos.",
+es gelten wieder Ihre Einstellungen für einzelne Abos.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     else:
         s["all"] = True
         context.bot.send_message(text="Sie werden alle Updates erhalten, \
-Ihre aktuellen Abo Einstellungen werden ignoriert.",
+Ihre aktuellen Abo Einstellungen werden ignoriert.\n\
+            /abo   /zeig   /menu",
                 chat_id=update.effective_chat.id)
     writer.write()


### PR DESCRIPTION
This update includes a new menu system which uses Markup Keyboards in telegram to offer clickable commands.
The structure contains a top-level menu and then three sub menus
- all subscription commands
- all show commands
- an extended help menu

There are also always clickable links to commands or sent keyboards itself after each command to make bot usage even easier.

I also restructured the show command.
The commands are now /adenau /brohltal etc which makes them clickable / executable without an external added keyword.
This makes the command even more robust, cause we don't need to check for an exact match of the given argument, because the new trigger commands are controlled by the bot and make sure that it is always a match.

All help commands are updated to the new structure as well.

I guess we can call this a mayor update and a soldi completion for `V1.0` of the bot.