### PR TITLE
🆕 Added incidence calculation and display on sent graphs

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -13,6 +13,20 @@ class Analyzer:
         self.cities = ["Adenau", "Altenahr", "Bad Breisig", "Brohltal", \
                        "Grafschaft", "Bad Neuenahr-Ahrweiler", "Remagen", "Sinzig"]
 
+        #Source: https://infothek.statistik.rlp.de/MeineHeimat/index.aspx?id=102&l=2&g=07131&tp=1025
+        #Numbers are from 31.12.2019
+        self.population = {
+            "Adenau": 13022,
+            "Altenahr": 10910,
+            "Bad Breisig": 13530,
+            "Brohltal": 18433,
+            "Grafschaft": 10977,
+            "Bad Neuenahr-Ahrweiler": 28468,
+            "Remagen": 17116,
+            "Sinzig": 17630
+
+        }
+
         self.date = date
 
         self.days = 20
@@ -115,8 +129,13 @@ class Analyzer:
                 linewidth=0.4, linestyle="-")
         ax.set_axisbelow(True)
 
+        #getting incidence
+        incidence = self.incidence(city)
+
         # extending plot for disclaimer
-        plt.title(f"Neuinfektionen {city} - Stand {self.date}")
+        plt.title(f"Neuinfektionen {city} - Stand {self.date}\n"
+                  f"Inzidenz: {incidence}")
+
         plt.gcf().subplots_adjust(bottom=0.28)
         #plt.gcf().autofmt_xdate()
 
@@ -137,4 +156,5 @@ Dieser Bot ist ein privates Projekt und steht in keiner Verbindung zu einer Beh√
 
 
 if __name__ == '__main__':
-    ana = Analyzer(datetime.date.today())
+    ana = Analyzer(datetime.date.today() - datetime.timedelta(1))
+    ana.incidence("Sinzig")


### PR DESCRIPTION
This update adds calculation of the current incidence value for each location and display it on the graph.
 
The calculation is based on the collected data and population numbers published by Rheinland-Pfalz.

***There are two possible edge cases in the calculation:***
Both appear at a data gap.

* The 8th day (and maybe 9th+) are missing
Handled trough checking wether this case exists.
If it is the case, the missing days will be counted and the last available number in the seven days interval will be divided by the amount of missing days. 
-> This leads to an approximation of the data from the last day in the array  
That case will happen rather regular.

* Day 8 and 7 (minus) are missing
This case is more unlikely but can happen in combination with the case described above and is not handled. 
Means that if day 7 and 8 are missing, day 7 will not be registered as missing, which will lead to a division of day 6's data by 2 instead of 3 (which would be correct).
This case can only occur when two or more following days are missing (and one part of those dates is inside the interval and the other part isn't), which is - looking at the collected data - rather unlikely to happen.  

  
It's no problem if there's a gap inside the seven days interval, because all days will be summ.
-> Day 5 will contains day 6's value if 6 is missing.
A gap at the first day can't happen because there's only an update when new data for the current day is published.

Source for population (from 31.12.2019)
https://infothek.statistik.rlp.de/MeineHeimat/index.aspx?id=102&l=2&g=07131&tp=1025