### PR TITLE
↗️ Add droneCI pipeline pushing docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,31 @@
+---
+kind: pipeline
+name: default
+type: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: push docker image
+  image: plugins/docker
+  settings:
+    tags: latest
+    squash: true
+    pull_image: true
+    compress: true
+    no_cache: true
+    experimental: true
+    dockerfile: Dockerfile
+    context: .
+    repo: nonchris/telegram-update-bot
+    username:
+      from_secret: DOCKER_USERNAME
+    password:
+      from_secret: DOCKER_PASSWORD
+  when:
+    branch:
+    - main
+    event:
+    - push


### PR DESCRIPTION
Please merge into master once you've set the secret `DOCKER_PASSWORD`.

What this pipeline does:
- get's triggered by every push into the master
- builds the image `nonchris/telegram-update-bot:latest`
- always pulls the newest version of the baseimage image
- no_cache -> always building everything
- compress -> saving storage & data
- squash -> image gets reduced to a single layer
- experimental -> needed for squash & compress

Secrets:
- `DOCKER_PASSWORD` -> create a DockerHub access token
- `DOCKER_USERNAME` -> name your DockerHub username

Both secrets can be set for the whole droneCI service!